### PR TITLE
Fix browser fetch binding for WebClient

### DIFF
--- a/components/dashboard/ClientProvider.tsx
+++ b/components/dashboard/ClientProvider.tsx
@@ -13,6 +13,11 @@ export const ClientContext = createContext(
 const MayNeedLogin = dynamic(() => import("./MayNeedLogin"));
 const client = new WebClient();
 
+// In browsers, calling the raw global fetch through an unbound class property
+// can trigger "Illegal invocation". Re-wrap it so the client always uses a
+// safe callable function.
+client.fetch = (...args) => fetch(...args);
+
 const ClientProvider = ({ children }: { children: React.ReactNode }) => {
 	const [state, setState] = useState(State.FirstLoading);
 


### PR DESCRIPTION
## Summary
- wrap the browser etch used by WebClient in a safe callable function
- prevent TypeError: Failed to execute 'fetch' on 'Window': Illegal invocation
- keep the fix isolated to the client bootstrap without changing other dashboard behavior

## Context
While testing the self-hosted deployment in Chrome, login and subsequent client calls could fail because etch was being used through an unbound class property. Re-wrapping it avoids the browser invocation error while preserving the same request flow.

## Testing
- verified the client no longer throws Illegal invocation during login flow
- deployed and exercised the fix in the self-hosted fork before isolating this patch
